### PR TITLE
Remove Duplicate updateStrategy Key

### DIFF
--- a/lacework-agent/templates/daemonset.yaml
+++ b/lacework-agent/templates/daemonset.yaml
@@ -11,8 +11,6 @@ spec:
   selector:
     matchLabels:
       name: {{ include "lacework-agent.name" . }}
-  updateStrategy:
-    type: RollingUpdate
   template:
     metadata:
       labels:


### PR DESCRIPTION
It looks like this key was accidentally duplicated.

Removing L14-L15, since the other duplicate seems to have intentionally been set up to be configurable.