### PR TITLE
Proxy scanner: Check config map for changes to trigger rolling upgrade

### DIFF
--- a/proxy-scanner/templates/deployment.yaml
+++ b/proxy-scanner/templates/deployment.yaml
@@ -14,6 +14,8 @@ spec:
     metadata:
       labels:
         app: {{ include "scanner.fullname" . }}
+      annotations:
+        "lacework-proxy-scanner/config-checksum": {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
     spec:
       {{- if .Values.serviceAccount.enabled }}
       serviceAccountName: {{ .Values.name }}


### PR DESCRIPTION
Current behaviour: when updating the config map for the proxy scanner (for example adding new container registry) the proxy scanner deployment will not be upgraded. To apply the new changes the proxy-scanner pod has to be deleted manually to trigger a deployment of a new pod using the new config map.

New behaviour: The config map checksum is checked and if the config map is updated a rolling upgrade is triggered. Therefore the changes are automatically applied and no manual intervention is required.