### PR TITLE
Make creating the accessToken optional

### DIFF
--- a/lacework-agent/templates/access-token.yaml
+++ b/lacework-agent/templates/access-token.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.laceworkConfig.createSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -12,3 +13,4 @@ metadata:
 type: Opaque
 data:
   agent-access-token: {{ required "A valid AccessToken is required! Specify your Lacework agent token in values.yaml" .Values.laceworkConfig.accessToken | b64enc }}
+{{- end }}

--- a/lacework-agent/values.yaml
+++ b/lacework-agent/values.yaml
@@ -24,8 +24,9 @@ resources:
 laceworkConfig:
   # [Required] An access token is required before running agents.
   # Visit https://<LACEWORK UI URL> for eg: https://lacework.lacework.net
+  # Default true. Set this to vault to not create the accessToken secret
   createSecret: true
-  accessToken: "fake"
+  accessToken: "Your Access Token Goes Here"
   # [Optional] Define custom annotations to use for identifying resources created by these charts
   annotations: {}
   # [Optional] Set to "disable" to disable autoupgrade of the datacollector

--- a/lacework-agent/values.yaml
+++ b/lacework-agent/values.yaml
@@ -24,7 +24,7 @@ resources:
 laceworkConfig:
   # [Required] An access token is required before running agents.
   # Visit https://<LACEWORK UI URL> for eg: https://lacework.lacework.net
-  # Default true. Set this to vault to not create the accessToken secret
+  # Default true. Set this to false to not create the accessToken secret
   createSecret: true
   accessToken: "Your Access Token Goes Here"
   # [Optional] Define custom annotations to use for identifying resources created by these charts

--- a/lacework-agent/values.yaml
+++ b/lacework-agent/values.yaml
@@ -24,7 +24,8 @@ resources:
 laceworkConfig:
   # [Required] An access token is required before running agents.
   # Visit https://<LACEWORK UI URL> for eg: https://lacework.lacework.net
-  accessToken:
+  createSecret: true
+  accessToken: "fake"
   # [Optional] Define custom annotations to use for identifying resources created by these charts
   annotations: {}
   # [Optional] Set to "disable" to disable autoupgrade of the datacollector


### PR DESCRIPTION
Hey Lacework,

We are trying to use the helm chart but do not wish to include our accessToken in source control.
To set up our lacework accessToken to be set from Hashicorp Vault, we need to be able to ignore the `kind: Secret` created by the lacework agent chart. 

I made a patch, but don't know how to PR into your helm-charts so that you can review.
https://github.com/arthurlm44/helm-charts

This is a quickfix, let me know your feedback. Thanks.