### PR TITLE
Lacework Agent - add the .helmignore file

### DIFF
--- a/lacework-agent/.helmignore
+++ b/lacework-agent/.helmignore
@@ -1,0 +1,27 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+# Bash scripts intended for development
+*.sh
+# the .helmignore file itself
+.helmignore


### PR DESCRIPTION
The .helmignore file excludes Bash scripts intended to use only for development.

Fix #73