### PR TITLE
Clarifying lacework-agent values

### DIFF
--- a/lacework-agent/values.yaml
+++ b/lacework-agent/values.yaml
@@ -1,86 +1,17 @@
 # Default values for Lacework Agent.
-image:
-  registry: docker.io
-  repository: lacework/datacollector
-  tag: 5.6.0
-  # imagePullPolicy should be Always to get the latest container
-  # http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
-  pullPolicy: Always
-  # [Optional] imagePullSecrets.
-  # https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
-  # imagePullSecrets:
-  #   - name: CustomerRegistrKeySecretName
-resources:
-  # The requests/limits is guidance and should be adjusted based on the workload
-  # Please contact Lacework support for additional details
-  # https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits
-  # https://support.lacework.com/hc/en-us/articles/360047019354-Usage-Impact-of-Agent-Deployment
-  requests:
-    cpu: 200m
-    memory: 512Mi
-  limits:
-    cpu: 500m
-    memory: 1450Mi
-laceworkConfig:
-  # [Required] An access token is required before running agents.
-  # Visit https://<LACEWORK UI URL> for eg: https://lacework.lacework.net
-  accessToken:
-  # [Optional] Define custom annotations to use for identifying resources created by these charts
-  annotations: {}
-  # [Optional] Define custom labels to use for identifying resources created by these charts
-  labels: {}
-  # [Optional] Set to "disable" to disable autoupgrade of the datacollector
-  autoUpgrade: enable
-  # [Optional] Give your k8s environment a friendly name
-  env:
-  # [Optional] Configure File Integrity Monitoring
-  # https://docs.lacework.com/configure-agent-behavior-in-configjson-file#file-integrity-monitoring-fim-properties
-  fim:
-    # [Optional] Configure coolingperiod in minutes
-    coolingPeriod:
-    # [Optional] Configure crawlinterval in minutes
-    crawlInterval:
-    enable: true
-    # [Optional] Configure file paths to ignore
-    fileIgnore: []
-    # [Optional] Configure file paths to include
-    filePath: []
-    # [Optional] Set to true to prevent atime from being used in metadata hash computation
-    noAtime:
-    # [Optional] Run the FIM scan interval at the specifid time of the day (HH:MM)
-    runAt:
-  # [Optional] Kubernetes cluster name
-  # https://support.lacework.com/hc/en-us/articles/360005263034-Deploy-on-Kubernetes
-  kubernetesCluster:
-  # [Optional] Route agent traffic through the specified proxy.
-  proxyUrl:
-  # [Required] Region specific Lacework service URL. Defaults to the US region.
-  serverUrl: https://api.lacework.net
-  # [Optional] Specify the service account for agent pods
-  serviceAccountName:
-  # [Optional] Set to false to prevent agent from sending diagnostic logs to stdout
-  stdoutLogging: true
-##########################################################################
-# Set daemonset priorityClassName
-priorityClassName:
-# Allow Lacework agent to run on all nodes including master node
-tolerations:
-  - effect: NoSchedule
-    key: node-role.kubernetes.io/master
-# Allow Lacework agent to run on all nodes in case of a taint
-# - effect: NoSchedule
-#   operator: Exists
 
+# daemonset -- [Required] Configure agent to run as daemonset
 daemonset:
-  # Use rolling updates in the DaemonSet
-  # https://kubernetes.io/docs/tasks/manage-daemon/update-daemon-set/
-  updateStrategy:
-    type: RollingUpdate
-  # DaemonSet to schedule using affinity rules
+  # daemonset.affinity -- [Optional] DaemonSet to schedule using affinity rules
   # https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
   affinity:
+    # daemonset.affinity.nodeAffinity -- [Optional] Node Affinity to be configured
     nodeAffinity:
+      # daemonset.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution -- [Optional]
+      #   Type of Node Affinity to be applied
       requiredDuringSchedulingIgnoredDuringExecution:
+        # daemonset.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms -- [Optional]
+        #   What terms should be matched for Affinity configuration.
         nodeSelectorTerms:
           - matchExpressions:
               - key: kubernetes.io/arch
@@ -92,3 +23,137 @@ daemonset:
                 operator: In
                 values:
                   - linux
+
+  # daemonset.UpdateStrategy -- [Optional] Use rolling updates in the DaemonSet
+  # https://kubernetes.io/docs/tasks/manage-daemon/update-daemon-set/
+  updateStrategy:
+    # daemonset.UpdateStrategy.type -- [Optional] Type of UpdateStrategy to use
+    type: RollingUpdate
+  
+
+# Image Configuration
+image:
+  # image.imagePullSecrets -- Secret name where secrets needed to pull image are located.
+  # [Optional] imagePullSecrets.
+  # https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  # imagePullSecrets:
+  #   - name: CustomerRegistrKeySecretName
+
+  # image.pullPolicy -- Pull policy of container
+  # imagePullPolicy should be Always to get the latest container
+  # http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+  pullPolicy: Always
+
+  # image.registry -- Registry where image is located
+  registry: docker.io
+
+  # image.repository -- Repository of image
+  repository: lacework/datacollector
+
+  # image.tag -- Tag of image to be used
+  tag: 5.6.0
+
+# Lacework Configuration
+laceworkConfig:
+  # laceworkConfig.accessToken -- Access Token configuration used by pod
+  # [Required] An access token is required before running agents.
+  # Visit https://<LACEWORK UI URL> for eg: https://lacework.lacework.net
+
+  # laceworkConfig.accessToken: If string, secret is created from value.
+  accessToken:
+
+  # Example accessToken when existing secret is used.
+  # accessToken:
+  #   # laceworkConfig.accessToken.existingSecret -- [Required] Whether the accessToken already exists in another secret.
+  #   existingSecret:
+  #     # laceworkConfig.accessToken.existingSecret.name -- [Required] Secret name is required when using an existing secret.
+  #     name: lacework-access-token
+
+  #     # laceworkConfig.accessToken.existingSecret.key -- [Required] Secret key is required when using an existing secret.
+  #     key: access-token
+
+  # laceworkConfig.annotations -- [Optional] Define custom annotations to use for identifying resources created by these charts
+  annotations: {}
+
+  # laceworkConfig.autoUpgrade -- [Optional] Set to "disable" to disable autoupgrade of the datacollector
+  autoUpgrade: enable
+
+  # laceworkConfig.env -- [Optional] Give your k8s environment a friendly name
+  env:
+
+  # laceworkConfig.fim -- [Optional] Configure File Integrity Monitoring
+  # https://docs.lacework.com/configure-agent-behavior-in-configjson-file#file-integrity-monitoring-fim-properties
+  fim:
+    # laceworkConfig.fim.coolingPeriod -- [Optional] Configure coolingperiod in minutes
+    coolingPeriod:
+
+    # laceworkConfig.fim.crawlInterval -- [Optional] Configure crawlinterval in minutes
+    crawlInterval:
+
+    # laceworkConfig.fim.enable -- [Required] Whether to enable or disable FIM.
+    enable: true
+
+    # laceworkConfig.fim.fileIgnore -- [Optional] Configure file paths to ignore
+    fileIgnore: []
+
+    # laceworkConfig.fim.filePath -- [Optional] Configure file paths to include
+    filePath: []
+
+    # laceworkConfig.fim.noAtime -- [Optional] Set to true to prevent atime from being used in metadata hash computation
+    noAtime:
+
+    # laceworkConfig.fim.runAt -- [Optional] Run the FIM scan interval at the specifid time of the day (HH:MM)
+    runAt:
+
+  # laceworkConfig.kubernetesCluster -- [Optional] Kubernetes cluster name
+  # https://support.lacework.com/hc/en-us/articles/360005263034-Deploy-on-Kubernetes
+  kubernetesCluster:
+
+  # laceworkConfig.labels -- [Optional] Define custom labels to use for identifying resources created by these charts
+  labels: {}
+
+  # laceworkConfig.proxyUrl -- [Optional] Route agent traffic through the specified proxy.
+  proxyUrl:
+
+  # laceworkConfig.serverUrl -- [Required] Region specific Lacework service URL. Defaults to the US region.
+  serverUrl: https://api.lacework.net
+
+  # laceworkConfig.serviceAccountName -- [Optional] Specify the service account for agent pods
+  serviceAccountName:
+
+  # laceworkConfig.stdoutLogging -- [Optional] Set to false to prevent agent from sending diagnostic logs to stdout
+  stdoutLogging: true
+
+# priorityClassName -- [Optional] Set daemonset priorityClassName
+priorityClassName:
+
+# Container resources
+resources:
+  # resources.limits -- Limits for resources set on pods
+  limits:
+    # resources.limits.cpu -- CPU Limits
+    cpu: 500m
+
+    # resources.limits.memory -- Memory Limits
+    memory: 1450Mi
+
+  # resources.requests -- Requests for resources by pod.
+  # The requests/limits is guidance and should be adjusted based on the workload
+  # Please contact Lacework support for additional details
+  # https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits
+  # https://support.lacework.com/hc/en-us/articles/360047019354-Usage-Impact-of-Agent-Deployment
+  requests:
+    # resources.requests.cpu -- CPU Requests
+    cpu: 200m
+
+    # resources.requests.memory -- Memory Requests
+    memory: 512Mi
+
+# tolerations -- [Optional] Allow Lacework agent to run on all nodes including master node
+tolerations:
+  - effect: NoSchedule
+    key: node-role.kubernetes.io/master
+  # Allow Lacework agent to run on all nodes in case of a taint
+  # - effect: NoSchedule
+  #   operator: Exists
+


### PR DESCRIPTION
The original `values.yaml` is a bit difficult to parse and missing at least one example (when `laceworkConfig.accessToken` is a map, not a string).  It sorts everything alphabetically and adds specific key references so that when you're traversing the YAML file, you can still understand where each key belongs.