### PR TITLE
Agent Charts: Enable custom keys at top-level

### DIFF
--- a/lacework-agent/values.schema.json
+++ b/lacework-agent/values.schema.json
@@ -347,7 +347,7 @@
             ]
         }
     },
-    "additionalProperties": false,
+    "additionalProperties": true,
     "definitions": {
         "io.k8s.api.core.v1.Affinity": {
             "description": "Affinity is a group of affinity scheduling rules.",


### PR DESCRIPTION
Give customers the ability to mix-in their own custom values files that
may contain keys unknown to the Lacework Agent charts. The tradeoff is
that our charts will continue to install even if the customer provides a
typo'd value name, however that should be rare for values specified at
the top-level.
