### PR TITLE
Fix service selector variable

### DIFF
--- a/proxy-scanner/templates/service.yaml
+++ b/proxy-scanner/templates/service.yaml
@@ -7,7 +7,7 @@ metadata:
   name: {{ include "scanner.fullname" . }}
 spec:
   selector:
-    app: {{ .Values.name }}
+    app: {{ include "scanner.fullname" . }}  
   ports:
     - port: 8080
       targetPort: 8080


### PR DESCRIPTION
If the .Values.name is defined and the user passes release name via helm cli , then we should set selector as `{{ include "scanner.fullname" . }}` otherwise service will become inaccessible