### PR TITLE
Add ArtifactHub Ownership file

### DIFF
--- a/artifacthub-repo.yml
+++ b/artifacthub-repo.yml
@@ -1,0 +1,5 @@
+# Artifact Hub repository metadata file
+repositoryID: 23b288a2-7dea-43f5-b382-26e20aa846d5
+owners:
+  - name: Shawn Marriot
+    email: shawn.marriott@lacework.net


### PR DESCRIPTION
Add this file to set this repository as the official source for Lacwork Helm Charts.
