### PR TITLE
Added imagePullSecrets to admission-controller and proxy-scanner. Version increased to 0.24.0

### DIFF
--- a/admission-controller/Chart.yaml
+++ b/admission-controller/Chart.yaml
@@ -1,18 +1,18 @@
 apiVersion: v2
 appVersion: "0.0.1"
-version: 0.23.0
+version: 0.24.0
 name: admission-controller
 description: Lacework admission controller using Lacework proxy scanner
 type: application
 keywords:
-- admission-controller
-- runtime-security
-- lacework
+  - admission-controller
+  - runtime-security
+  - lacework
 maintainers:
-- name: chitrapkumar
-  email: chitra.kumar@lacework.net
+  - name: chitrapkumar
+    email: chitra.kumar@lacework.net
 dependencies:
-- name: proxy-scanner
-  version: 0.23.0
-  condition: proxy-scanner.enabled
-  repository: https://lacework.github.io/helm-charts
+  - name: proxy-scanner
+    version: 0.24.0
+    condition: proxy-scanner.enabled
+    repository: https://lacework.github.io/helm-charts

--- a/admission-controller/templates/deployment.yaml
+++ b/admission-controller/templates/deployment.yaml
@@ -22,6 +22,10 @@ spec:
         runAsGroup: 11433
         fsGroup: 11433
       serviceAccountName: {{ .Values.serviceAccount.name }}
+{{- if .Values.deployment.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.deployment.imagePullSecrets | indent 8 }}
+{{- end }}
       containers:
         - name: {{ include "admission.name" . }}
           image: "{{ .Values.deployment.image }}:{{ .Values.deployment.tag }}"

--- a/admission-controller/values.yaml
+++ b/admission-controller/values.yaml
@@ -12,12 +12,12 @@ admission:
   # All other resources may spawn multiple child resources,
   # and you will need to exclude all of these if you want to prevent excessive scanning during the deployment.
   excluded_resources:
-  - "Deployment"
-  - "ReplicaSet"
-  - "DaemonSet"
-  - "Job"
-  - "CronJob"
-  - "StatefulSet"
+    - "Deployment"
+    - "ReplicaSet"
+    - "DaemonSet"
+    - "Job"
+    - "CronJob"
+    - "StatefulSet"
 
 policy:
   block_exec: false
@@ -63,7 +63,8 @@ securityContext:
   fsGroup: 11433
 container_securityContext: {}
 
-resources: {}
+resources:
+  {}
   # requests:
   #   cpu: 250m
   #   memory: 0.2Gi
@@ -75,8 +76,12 @@ nodeSelector: {}
 
 deployment:
   image: lacework/lacework-admission-controller
-  tag: 0.23.0
+  tag: 0.24.0
   pullPolicy: Always
+  # [Optional] imagePullSecrets.
+  # https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  # imagePullSecrets:
+  #   - name: CustomerRegistrKeySecretName
   replicaCount: 1
   service:
     port: 8443
@@ -89,6 +94,15 @@ proxy-scanner:
 
   resources: {}
 
+  replicaCount: 1
+  image: lacework/lacework-proxy-scanner
+  tag: 0.24.0
+  pullPolicy: Always
+  # [Optional] imagePullSecrets.
+  # https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  # imagePullSecrets:
+  #   - name: CustomerRegistrKeySecretName
+
   config:
     default_registry:
     static_cache_location: /opt/lacework
@@ -98,25 +112,25 @@ proxy-scanner:
     lacework:
       account_name:
       integration_access_token:
-#    registry_secret_name:
+    #    registry_secret_name:
     registries:
-#      - domain:
-#        name:
-#        ssl:
-#        type:
-#        auto_poll:
-#        is_public:
-#        auth_type:
-#        auth_header_name: Authorization
-#        credentials:
-#          user_name:
-#          password:
-#        notification_type:
-#        poll_frequency_minutes: 20
-#        disable_non_os_package_scanning: false
-#        go_binary_scanning:
-#          enable: false
-#          scan_directory_path: ""
+  #      - domain:
+  #        name:
+  #        ssl:
+  #        type:
+  #        auto_poll:
+  #        is_public:
+  #        auth_type:
+  #        auth_header_name: Authorization
+  #        credentials:
+  #          user_name:
+  #          password:
+  #        notification_type:
+  #        poll_frequency_minutes: 20
+  #        disable_non_os_package_scanning: false
+  #        go_binary_scanning:
+  #          enable: false
+  #          scan_directory_path: ""
 
   certs:
     skipCert: true

--- a/proxy-scanner/Chart.yaml
+++ b/proxy-scanner/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: proxy-scanner
 description: A Helm chart for Lacework Proxy Scanner
 type: application
-version: 0.23.0
+version: 0.24.0
 appVersion: "1.0"

--- a/proxy-scanner/templates/deployment.yaml
+++ b/proxy-scanner/templates/deployment.yaml
@@ -23,10 +23,14 @@ spec:
       {{- if .Values.serviceAccount.enabled }}
       serviceAccountName: {{ .Values.name }}
       {{- end }}
-
+{{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.imagePullSecrets | indent 8 }}
+{{- end }}
       containers:
       - name: {{ include "scanner.name" . }}
-        image: {{ .Values.image }}
+        image: "{{ .Values.image }}:{{ .Values.tag }}"
+        imagePullPolicy: {{ .Values.pullPolicy }}
         env:
           - name: LOG_LEVEL
             value: {{ .Values.logLevel }}

--- a/proxy-scanner/values.yaml
+++ b/proxy-scanner/values.yaml
@@ -12,7 +12,13 @@ logLevel: "info"
 resources: {}
 
 replicaCount: 1
-image: lacework/lacework-proxy-scanner:0.23.0
+image: lacework/lacework-proxy-scanner
+tag: 0.24.0
+pullPolicy: Always
+# [Optional] imagePullSecrets.
+# https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+# imagePullSecrets:
+#   - name: CustomerRegistrKeySecretName
 
 podAnnotations: {}
 #  my-annotation-key: my value; more value


### PR DESCRIPTION
This PR adds optional support for imagePullSecrets to the admission-controller and proxy-scanner helm charts. This is required for prospects and customers using their own container registries. 

In addition the version numbers have been increase from 0.23.0 to 0.24.0 for the helm-charts and images used. It needs to be clarified if this works as part of the release process of the container images for admission-controller and proxy-scanner.