### PR TITLE
feat(lacework-agent): Add functionality for mounting additional volumes

### DIFF
--- a/lacework-agent/Chart.yaml
+++ b/lacework-agent/Chart.yaml
@@ -14,4 +14,4 @@ maintainers:
 - email: info@lacework.net
   name: lacework-support
 name: lacework-agent
-version: 6.13.0
+version: 6.14.0

--- a/lacework-agent/templates/daemonset.yaml
+++ b/lacework-agent/templates/daemonset.yaml
@@ -113,6 +113,9 @@ spec:
             readOnly: true
           - name: podinfo
             mountPath: /etc/podinfo
+          {{- if .Values.volumeMounts }}
+            {{- toYaml .Values.volumeMounts | nindent 10 }} 
+          {{- end }}
 {{- if kindIs "string" (.Values.laceworkConfig).serviceAccountName }}
       serviceAccountName: {{ (.Values.laceworkConfig).serviceAccountName | quote }}
 {{- end}}
@@ -181,6 +184,9 @@ spec:
               - path: "namespace"
                 fieldRef:
                   fieldPath: metadata.namespace
+        {{- if .Values.volumes }}
+          {{- toYaml .Values.volumes | nindent 8 }}
+        {{- end }}
   updateStrategy:
 {{ toYaml (.Values.daemonset).updateStrategy | indent 4 }}
 {{- end }}

--- a/lacework-agent/values.schema.json
+++ b/lacework-agent/values.schema.json
@@ -576,6 +576,22 @@
             },
             "additionalProperties": false
         },
+        "volumes": {
+            "type": "array",
+            "default": [],
+            "description": "Array of Additional Volumes",
+            "items": {
+                "type": "object"
+            }
+        },
+        "volumeMounts": {
+            "type": "array",
+            "default": [],
+            "description": "Array of Additional Volume Mounts",
+            "items": {
+                "type": "object"
+            }
+        },
         "resources": {
             "$ref": "#/definitions/io.k8s.api.core.v1.ResourceRequirements",
             "description": "Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/"

--- a/lacework-agent/values.yaml
+++ b/lacework-agent/values.yaml
@@ -11,6 +11,15 @@ image:
   # imagePullSecrets:
   #   - name: CustomerRegistrKeySecretName
   overrideValue:
+
+# [Optional] Additional Volumes for the agent Pod.
+# https://kubernetes.io/docs/concepts/storage/volumes/
+volumes: []
+
+# [Optional] Additional Volume Mounts for the agent container.
+# (https://kubernetes.io/docs/concepts/storage/volumes/
+volumeMounts: []
+
 resources:
   # The requests/limits is guidance and should be adjusted based on the workload
   # Please contact Lacework support for additional details


### PR DESCRIPTION
Hi guys, 

Should be a fairly simple addition to the main chart that has been bugging me for a while. 

The main goal of this PR is to allow mounting volumes to the lacework agent container. The main use case for us with this change is for mounting Kubernetes secrets to the container like the agent token. This means we do not have to hard code these in the helm chart. 

We have been running with this from our own fork of the chart for a while but figured it was time to propose it for the main chart as well.

Thanks,
Adam