### PR TITLE
feat(lacework-agent) Optionally create clusterAgent templated resources

### DIFF
--- a/lacework-agent/templates/cluster-role-binding.yaml
+++ b/lacework-agent/templates/cluster-role-binding.yaml
@@ -1,4 +1,4 @@
-{{- if (.Values.clusterAgent).enable -}}
+{{- if (and (.Values.clusterAgent).enable (.Values.clusterAgent).createRoleBinding) -}}
 apiVersion: rbac.authorization.k8s.io/v1
 # This cluster role binding allows anyone in the "manager" group to read secrets in any namespace.
 kind: ClusterRoleBinding

--- a/lacework-agent/templates/cluster-role.yaml
+++ b/lacework-agent/templates/cluster-role.yaml
@@ -1,4 +1,4 @@
-{{- if (.Values.clusterAgent).enable -}}
+{{- if (and (.Values.clusterAgent).enable (.Values.clusterAgent).createRole) -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/lacework-agent/templates/service-account.yaml
+++ b/lacework-agent/templates/service-account.yaml
@@ -1,4 +1,4 @@
-{{- if (.Values.clusterAgent).enable -}}
+{{- if (and (.Values.clusterAgent).enable (.Values.clusterAgent).createServiceAccount) -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/lacework-agent/values.yaml
+++ b/lacework-agent/values.yaml
@@ -38,6 +38,9 @@ clusterAgent:
   # https://docs.lacework.net/onboarding/restricted/configure-agent-behavior-in-configjson-file#proxyurl-propert
   proxyUrl:
   hostNetworkAccess: false
+  createRoleBinding: true
+  createRole: true
+  createServiceAccount: true
   image:
     registry: docker.io
     repository: lacework/k8scollector


### PR DESCRIPTION
When using clusterAgent.enable make optional creating the rbac resources by setting clusterAgent.createRoleBinding: to create the ClusterRoleBinding clusterAgent.createRole: to create the ClusterRole clusterAgent.createServiceAccount: to create the ServiceAccount